### PR TITLE
Feat: Implement SafeBackHandler for Android and PDF Picker using Calf

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.declarative.dsl.schema.FqName.Empty.packageName
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
@@ -89,6 +88,9 @@ kotlin {
             implementation(libs.firebase.messaging)
             implementation(libs.foundation)
             implementation(libs.foundation.layout)
+            // Only inside androidMain
+            implementation("androidx.activity:activity-compose:1.7.2")
+//            implementation("org.apache.pdfbox:pdfbox:2.0.27")
 //            implementation(libs.accompanist.pager)
 //            implementation(libs.accompanist.pager.indicators)
         }
@@ -152,6 +154,7 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
+            //noinspection WrongGradleMethod
             firebaseCrashlytics {
                 mappingFileUploadEnabled = true
             }

--- a/composeApp/src/commonMain/kotlin/com/dailydevchallenge/devstreaks/utils/PlatformUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/dailydevchallenge/devstreaks/utils/PlatformUtils.kt
@@ -14,4 +14,7 @@ interface PdfPickerHandler {
 
 expect fun getPdfPickerHandler(): PdfPickerHandler
 
+@Composable
+expect fun SafeBackHandler(enabled: Boolean = true, onBack: () -> Unit)
+
 

--- a/composeApp/src/iosMain/kotlin/com/dailydevchallenge/devstreaks/utils/PlatformUtils.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/dailydevchallenge/devstreaks/utils/PlatformUtils.ios.kt
@@ -1,7 +1,51 @@
 package com.dailydevchallenge.devstreaks.utils
 
+import androidx.compose.runtime.Composable
 import com.dailydevchallenge.devstreaks.utils.PdfPickerHandler
+import androidx.compose.runtime.*
+import com.mohamedrejeb.calf.core.LocalPlatformContext
+import com.mohamedrejeb.calf.io.KmpFile
+import com.mohamedrejeb.calf.io.getName
+import com.mohamedrejeb.calf.io.readByteArray
+import com.mohamedrejeb.calf.picker.*
+import kotlinx.coroutines.launch
 
-actual fun getPdfPickerHandler(): PdfPickerHandler {
-    TODO("Not yet implemented")
+@Composable
+actual fun SafeBackHandler(enabled: Boolean, onBack: () -> Unit) {
+    // No-op on iOS
+}
+
+actual fun getPdfPickerHandler(): PdfPickerHandler = CalfPdfPickerHandler
+
+object CalfPdfPickerHandler : PdfPickerHandler {
+    @Composable
+    override fun PickPdf(onTextExtracted: (String) -> Unit) {
+        val coroutineScope = rememberCoroutineScope()
+        val context = LocalPlatformContext.current
+        val launcher = rememberFilePickerLauncher(
+            type = FilePickerFileType.Pdf,
+            selectionMode = FilePickerSelectionMode.Single,
+            onResult = { files ->
+                val file = files.firstOrNull()
+                if (file != null) {
+                    coroutineScope.launch {
+                        // iOS and Android both support these suspend functions
+                        val fileName = file.getName(context) ?: "Unknown"
+                        val fileBytes = file.readByteArray(context)
+                        val fileSizeKb = fileBytes.size / 1024
+                        val summary = "📄 $fileName ($fileSizeKb KB)"
+                        onTextExtracted(summary)
+
+                        // You can now use fileBytes to upload/analyze
+                    }
+                } else {
+                    onTextExtracted("❌ No file selected")
+                }
+            }
+        )
+
+        LaunchedEffect(Unit) {
+            launcher.launch()
+        }
+    }
 }


### PR DESCRIPTION
This commit introduces a `SafeBackHandler` composable for Android to manage back navigation, particularly in the onboarding flow. It also implements a PDF picker functionality using the Calf library for both Android and iOS platforms.

Key changes:

- **`SafeBackHandler`**:
    - Added `SafeBackHandler` expect/actual functions.
    - Android implementation uses `androidx.activity.compose.BackHandler`. fixed the issue reported for navigation back from LearningIntentScreen.kt to home with confirmation